### PR TITLE
update instruction on main.tex

### DIFF
--- a/Conda Setup/main.tex
+++ b/Conda Setup/main.tex
@@ -170,7 +170,7 @@ conda activate <your-env-name>
 Next, in the active environment type:
 \begin{lstlisting}[language=bash]
 #install ipykernel
-conda install -c anaconda ipykernel
+conda install -c anaconda ipykernel notebook
 #install the new kernel
 ipython kernel install --user --name=<your-env-name>
 \end{lstlisting}


### PR DESCRIPTION
In step 3, when I ran `jupyter notebook`, I got the error saying that `jpyter-notebook` was not found.

```sh
(XCS330) xxx@xxx-MacBook-Air XCS330-PS1 % jupyter notebook
...
Jupyter command `jupyter-notebook` not found.
```

I then ran `conda list` to view all the dependencies in the environment. Turns out that `notebook` is not in the dependency list. 

```sh
conda list

...
ncurses                   6.4                  h313beb8_0  
nest-asyncio              1.6.0           py310hca03da5_0    anaconda
networkx                  3.4.2                    pypi_0    pypi
nltk                      3.9.1                    pypi_0    pypi
numexpr                   2.10.1          py310h5d9532f_0  
numpy                     2.2.2           py310h3b2db8e_0  
numpy-base                2.2.2           py310ha9811e2_0  
...
```

Therefore we should update the instruction to install notebook.